### PR TITLE
fix(projects page): tailwind colors project component

### DIFF
--- a/src/lib/projects.json
+++ b/src/lib/projects.json
@@ -1,27 +1,23 @@
 [
   {
     "name": "Bridging the Rift",
-    "color": "bg-blue",
     "description": "A platformer game in which the player collects materials to help build bridges after a natural disaster. Made using Godot in C#.",
     "video": "/btr.mp4",
     "link": "https://github.com/emilyrhee/bridging-the-rift"
   },
   {
     "name": "emilyrhee.me",
-    "color": "bg-red",
     "description": "The website you are on right now! Created using the Sveltekit framework and Tailwind CSS. Prototyped in Figma Design.",
     "link": "https://github.com/emilyrhee/personal-site"
   },
   {
     "name": "Room Tour",
-    "color": "bg-green",
     "description": "A game where I give a tour of my bedroom. The player walks into furniture to display a factoid about it. Made using Java + JavaFX.",
     "video": "/roomtour.mp4",
     "link": "https://github.com/emilyrhee/room-tour"
   },
   {
-    "name":"GPT",
-    "color": "bg-light-brown",
+    "name": "GPT",
     "description": "A group project to create a generative pre-trained transformer which takes input text data, trains off of it, and outputs text of a similar style. Made using Python + PyTorch.",
     "link": "https://github.com/CCSU-AI-2024/gpt"
   }

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -1,14 +1,19 @@
-<head>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-  <link href="https://fonts.googleapis.com/css2?family=Coiny&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
-</head>
-
 <script lang="ts">
-  import NavBar from '$lib/NavBar.svelte'
-  import Project from './Project.svelte';
-  import projects from '$lib/projects.json';
+  import NavBar from "$lib/NavBar.svelte";
+  import Project from "./Project.svelte";
+  import projects from "$lib/projects.json";
+
+  const colors = ["bg-blue", "bg-red", "bg-green", "bg-light-brown"];
 </script>
+
+<head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Coiny&family=JetBrains+Mono:wght@400;600&display=swap"
+    rel="stylesheet"
+  />
+</head>
 
 <body class="bg-beige px-4 sm:px-6 md:px-8 lg:px-16 xl:px-32 2xl:px-48">
   <NavBar />
@@ -20,8 +25,8 @@
 
     <div class="py-4"></div>
 
-    {#each projects as project}
-      <Project {project} />
+    {#each projects as project, index}
+      <Project {project} {colors} {index} />
     {/each}
   </div>
 </body>

--- a/src/routes/projects/Project.svelte
+++ b/src/routes/projects/Project.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import Bolts from '$lib/Bolts.svelte';
+  import Bolts from "$lib/Bolts.svelte";
 
   export let project;
+  export let colors;
+  export let index;
 
   let description: string = "";
   let max: number = 75;
@@ -23,31 +25,36 @@
   }
 </script>
 
-<div class="relative {project.color} text-lg text-beige font-jetbrains p-12 rounded-md">
-    <Bolts />
-    
-    <h2 class="text-beige text-4xl font-coiny">{project.name}</h2>
-    <p class="py-2 text-beige font-jetbrains">
-      {description} 
-      {#if !isDescriptionFull}
-        <button class="underline" on:click={showDescription}>...more</button>
-      {/if}
-      {#if isDescriptionFull}
-        <div>
-          {#if project.video}
-            <div class="py-1"></div>
-            <video controls muted class="rounded-md">
-              <source src="{project.video}" type="video/mp4">
-            </video>
-            <div class="py-1"></div>
-          {/if}
-          <button class="underline" on:click={hideDescription}>
-            Show less
-          </button>
-        </div>
-      {/if}
-    </p>
-    <a href="{project.link}" target="_blank" class="underline font-bold">GitHub</a>
+<div
+  class="relative {colors[
+    index % colors.length
+  ]} text-lg text-beige font-jetbrains p-12 rounded-md"
+>
+  <Bolts />
+
+  <h2 class="text-beige text-4xl font-coiny">{project.name}</h2>
+  <p class="py-2 text-beige font-jetbrains">
+    {description}
+    {#if !isDescriptionFull}
+      <button class="underline" on:click={showDescription}>...more</button>
+    {/if}
+    {#if isDescriptionFull}
+      <div>
+        {#if project.video}
+          <div class="py-1"></div>
+          <video controls muted class="rounded-md">
+            <source src={project.video} type="video/mp4" />
+          </video>
+          <div class="py-1"></div>
+        {/if}
+        <button class="underline" on:click={hideDescription}>
+          Show less
+        </button>
+      </div>
+    {/if}
+  </p>
+  <a href={project.link} target="_blank" class="underline font-bold">GitHub</a>
 </div>
 
 <div class="py-4"></div>
+


### PR DESCRIPTION
Tailwind requires statically (build time) known class names or the CSS classes will not be included with the build of the project.

Also, I made it so that the projects "roll over" when more components than the list of colors is given. The project component should be responsible for styling instead of the JSON file which is really just there for the data or text "contents" of the component.